### PR TITLE
GSG: Minishift & CDK version update

### DIFF
--- a/docs/topics/minishift-install-nexus-setup.adoc
+++ b/docs/topics/minishift-install-nexus-setup.adoc
@@ -39,7 +39,7 @@ minishift start
 +
 [WARNING]
 --
-The procedure described below works with {Minishift} version `1.5.0`.
+The procedure described below works with {Minishift} version `1.7.0`.
 It has not been tested for use with CDK.
 You must use `oc` version `3.6.0` or later.
 --

--- a/docs/topics/secured-booster-minishift.adoc
+++ b/docs/topics/secured-booster-minishift.adoc
@@ -16,7 +16,7 @@ IMPORTANT: You must use a different boot iso image than the default in order for
 ----
 $ minishift delete
 $ rm -r ~/.minishift
-$ minishift start --memory=6144 --iso-url=https://github.com/minishift/minishift-centos-iso/releases/download/v1.0.0/minishift-centos7.iso
+$ minishift start --memory=6144 --iso-url=centos
 ----
 
 . Install {launcher} on {OpenShiftLocal} using the link:{link-launcher-openshift-local-install-guide}#create-launcher-app-script[instructions in the {openshift-local-guide-name} guide] making sure to specify `master` for the catalog version.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -69,8 +69,8 @@
 :wf-swarm-runtime-guide-name: {WildFlySwarm} Runtime Guide
 :nodejs-runtime-guide-name: {NodeJS} Runtime Guide
 
-:MinishiftVersion: 1.5.0
-:CDKVersion: 3.0.0
+:MinishiftVersion: 1.7.0
+:CDKVersion: 3.1.1
 
 :link-http-api-level-0-spring-boot-tomcat-booster: https://github.com/snowdrop/rest_springboot-tomcat
 :link-http-api-level-0-vertx-booster: https://github.com/openshiftio-vertx-boosters/vertx-http-booster


### PR DESCRIPTION
Updated the Minishift and CDK versions:
Minishift: `1.7.0`
CDK: `3.1.1`

@cescoffier Would you know of any currently open issues that would prevent us from updating to these versions?

resolves #707 