### PR TITLE
Script to sync WildFly Swarm sources

### DIFF
--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -57,6 +57,8 @@ include::topics/contributing-reviewing-changes.adoc[leveloffset=+3]
 
 include::topics/contributing-merging-changes.adoc[leveloffset=+3]
 
+include::topics/contributing-syncing-with-wildfly-swarm-docs.adoc[leveloffset=+3]
+
 include::topics/contributing-releasing-new-version.adoc[leveloffset=+3]
 
 === Issues

--- a/docs/topics/contributing-releasing-new-version.adoc
+++ b/docs/topics/contributing-releasing-new-version.adoc
@@ -18,6 +18,8 @@ This section contains all information you need to release a new version of the d
 Usually, update version `vX` to `vX+1`, for example `v3` to `v4`.
 --
 
+. Synchronize the {WildFlySwarm} sources. For more information, see xref:syncing-with-wildfly-swarm-docs[].
+
 . Update the current milestone in GitHub:
 .. Rename the _Current Development_ milestone to the current date in the _YYYY-MM-DD_ format.
 .. Create a new milestone called _Current Development._

--- a/docs/topics/contributing-syncing-with-wildfly-swarm-docs.adoc
+++ b/docs/topics/contributing-syncing-with-wildfly-swarm-docs.adoc
@@ -1,0 +1,27 @@
+
+[#syncing-with-wildfly-swarm-docs]
+= Syncing with {WildFlySwarm} Docs
+
+Some documentation files for the {WildFlySwarm} runtim are sourced directly from the {WildFlySwarm} repository.
+You must synchronize them manually before a release to ensure the newest version of the files is available.
+
+The synchronization script deletes the existing `$REPO_HOME/docs/topics/wildfly-swarm` directory and replaces it with the latest version of the `master` branch from the upstream repository.
+Edit the variables in the `$REPO_HOME/scripts/sync_with_wildfly_swarm.sh` script to customize it.
+The variables are documented in the script.
+
+NOTE: Some files are not present in the upstream repository because they are generated. The script automatically builds the upstream project with Maven, ensuring these files are not missing.
+
+WARNING: Do not edit the files in the `$REPO_HOME/docs/topics/wildfly-swarm` directory, always submit a pull request to the upstream repository and synchronize the files when they are updated upstream.
+
+.Prerequisites
+
+* Maven installed
+
+.Procedure
+
+. Execute the `$REPO_HOME/scripts/sync_with_wildfly_swarm.sh` script:
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ ./scripts/sync_with_wildfly_swarm.sh
+----

--- a/scripts/sync_with_wildfly_swarm.sh
+++ b/scripts/sync_with_wildfly_swarm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+SCRIPT_SRC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P )"           # Script source directory
+TEMP_DIR="$(mktemp -d)"                                                     # Temporary directory, will be deleted
+
+REPO_NAME="wildfly-swarm"                                                   # Repository base name, and the directory name on the disk
+REPO_URL="https://github.com/wildfly-swarm/${REPO_NAME}.git"                # Repo Git URL
+REPO_BRANCH="master"                                                        # Branch to be synchronized
+
+FILES_LIST="${SCRIPT_SRC}/wildfly-swarm-files.txt"                          # File with file- or directory names to synchronize
+FILES_DESTINATION="$(realpath ${SCRIPT_SRC}/../docs/topics/wildfly-swarm)"  # Destination directory in this repository where to sync
+
+git rm $FILES_DESTINATION
+
+echo "Cloning the WildFly Swarm repository..." >&2
+
+set -e
+
+pushd $TEMP_DIR &>/dev/null
+git clone $REPO_URL --depth 1 --branch $REPO_BRANCH
+cd $REPO_NAME/docs
+mvn clean install -DskipTests -Dswarm.product.build
+find -type d -name target -prune -exec rm -rf '{}' \;
+popd &>/dev/null
+
+echo "Copying files..." >&2
+
+mkdir -p $FILES_DESTINATION 2>/dev/null
+for line in $(cat $FILES_LIST); do
+    printf "$line" | grep -q '^\W*$' && continue # Ignore empty lines
+    printf "$line" | grep -q '^#' && continue # Ignore commented-out lines
+    pushd $TEMP_DIR/$REPO_NAME &>/dev/null
+    rsync -avhR $line $FILES_DESTINATION
+    popd &>/dev/null
+done
+
+echo "Committing changes..." >&2
+
+git add $FILES_DESTINATION
+git commit $FILES_DESTINATION -m "Synced WildFly Swarm sources"
+
+echo "Cleaning up..." >&2
+
+rm -rf $TEMP_DIR
+
+echo "Done." >&2
+

--- a/scripts/wildfly-swarm-files.txt
+++ b/scripts/wildfly-swarm-files.txt
@@ -1,0 +1,5 @@
+# List with files and/or directories to synchronize from the WildFly Swarm repository
+
+docs/howto
+docs/concepts
+docs/reference


### PR DESCRIPTION
The script does the following:

* Shallow-clones the WF Swarm repository in a termporary directory.
* Builds the upstream docs because some files we need are generated.
* Copies over files specified in the `scripts/wildfly-swarm-files.txt` to `docs/topics/wildfly-swarm` while keeping the original directory structure.
* Commits the files in the `docs/topics/wildfly-swarm` directory.
* Cleans up the temporary directory.