### PR TITLE
Fixed output of validation script

### DIFF
--- a/scripts/validate_guides.sh
+++ b/scripts/validate_guides.sh
@@ -21,7 +21,8 @@ done
 echo "=== Validating Guides ==="
 for book in $SCRIPT_SRC/../docs/*/master.adoc; do
     dir="$(dirname $book)"
-    echo -e "Processing $(basename $dir)"
+    book_name="$(basename $dir)"
+    echo -e "Processing $book_name"
     pushd $dir >/dev/null
 
     # Check if this book is ignored in the CI builds
@@ -32,16 +33,16 @@ for book in $SCRIPT_SRC/../docs/*/master.adoc; do
 
     # Build title into DocBook XML and see if any errors or warnings were output
     if asciidoctor master.adoc -b docbook5 2>&1 | grep "ERROR\|WARNING"; then
-        echo -e "Failed to build $dir."
-        failed_builds="$failed_builds $dir"
+        echo -e "Failed to build $book_name."
+        failed_builds="$failed_builds $book_name"
         popd >/dev/null
         continue
     fi
 
     # Validate the DocBook XML
     if ! xmllint --schema $XML_SCHEMA master.xml 1>/dev/null; then
-        echo "Failed to validate $dir."
-        failed_validations="$failed_validations $dir"
+        echo "Failed to validate $book_name."
+        failed_validations="$failed_validations $book_name"
     fi
     popd >/dev/null
 done


### PR DESCRIPTION
When a validation fails, the script outputs the full path of the book. With this fix, it outputs only the basename.