### PR TITLE
Issue #813: added note about running IT's in a separate project

### DIFF
--- a/docs/topics/note-integration-tests-app-deletion-warning.adoc
+++ b/docs/topics/note-integration-tests-app-deletion-warning.adoc
@@ -1,0 +1,5 @@
+[WARNING]
+--
+Executing integration tests removes all existing instances of the booster application from the target OpenShift project.
+To avoid accidentally removing your booster application, ensure that you create and select a separate OpenShift project to execute the tests.
+--

--- a/docs/topics/proc_running-the-secured-booster-integration-tests-on-sb-vx.adoc
+++ b/docs/topics/proc_running-the-secured-booster-integration-tests-on-sb-vx.adoc
@@ -14,6 +14,8 @@
 
 .Procedure
 
+include::note-integration-tests-app-deletion-warning.adoc[]
+
 . In a terminal application, navigate to the directory with your project.
 . Create the {RHSSO} server application:
 +

--- a/docs/topics/proc_running-the-secured-booster-integration-tests.adoc
+++ b/docs/topics/proc_running-the-secured-booster-integration-tests.adoc
@@ -15,6 +15,8 @@ endif::secured-wf-swarm-mission[]
 
 .Procedure
 
+include::note-integration-tests-app-deletion-warning.adoc[]
+
 . In a terminal application, navigate to the directory with your project.
 ifdef::secured-wf-swarm-mission,secured-spring-boot-mission[]
 . Deploy the {RHSSO} server:
@@ -36,4 +38,3 @@ $ mvn clean verify -Popenshift,openshift-it -DSSO_AUTH_SERVER_URL=$(oc get route
 --
 oc delete -f service.sso.yaml
 --
-


### PR DESCRIPTION
@Ladicek I've included a note in the SSO booster integration test procedure to warn the user against accidentally deleting their app. 