### PR TITLE
Replaced the string "WildFly" (not Swarm) with an attribute

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -30,6 +30,8 @@
 :VertX: Eclipse Vert.x
 :NodeJS: Node.js
 :RHSSO: Red Hat SSO
+// Needs to be set to either "WildFly" or "Red Hat JBoss EAP"
+:WildFly: Red Hat JBoss EAP
 
 :app-name: MY_APP_NAME
 :project-name: MY_PROJECT_NAME

--- a/docs/topics/wf-swarm-runtime-overview.adoc
+++ b/docs/topics/wf-swarm-runtime-overview.adoc
@@ -1,6 +1,9 @@
 = Runtime Details
 //http://wildfly-swarm.io
 
-{WildFlySwarm} deconstructs the features in link:http://wildfly.org[WildFly Java Application Server] and allows them to be selectively reconstructed based on the needs of your application. This allows you to create microservices that run on a _just-enough-appserver_ that supports the exact subset of APIs you need. Check out xref:wf-swarm-additional-resources[Additional Resources] for further reading on {WildFlySwarm}.
+{WildFlySwarm} deconstructs the features in
+ifndef::product[link:https://wildfly.org/[the {WildFly} Java application server]]
+ifdef::product[link:https://developers.redhat.com/products/eap/overview/[{WildFly}]]
+and allows them to be selectively reconstructed based on the needs of your application. This allows you to create microservices that run on a _just-enough-appserver_ that supports the exact subset of APIs you need. Check out xref:wf-swarm-additional-resources[Additional Resources] for further reading on {WildFlySwarm}.
 
 The {WildFlySwarm} runtime enables you to run {WildFlySwarm} applications and services in OpenShift while providing all the advantages and conveniences of the OpenShift platform such as rolling updates, service discovery, and canary deployments. OpenShift also makes it easier for your applications to implement common microservice patterns such as ConfigMap, Health Check, Circuit Breaker, and Failover.


### PR DESCRIPTION
Some of the diff is unrelated as it was brought in in the upstream sync. Look for the string `WildFly` being replaced with `{WildFly}`. To make the changes easier to read, we can wait for #872 to be merged and I'll rebase.

Resolves #819.