### PR TITLE
crud mision xref now points to crud IT section

### DIFF
--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -185,8 +185,11 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
+
 :parameter-runtime: spring-boot
 :parameter-runtime-name: {SpringBoot}
+:parameter-mission: crud
+:parameter-mission-name: {name-mission-crud}
 :context: {parameter-mission}-{parameter-runtime}
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
 
@@ -194,9 +197,6 @@ include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // design tradeoffs
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
-
-:parameter-mission: crud
-:parameter-mission-name: {name-mission-crud}
 
 :context: {parameter-mission}-oso
 include::topics/assembly_building-and-deploying-the-booster-to-openshiftonline.adoc[leveloffset=+3]
@@ -210,8 +210,6 @@ include::topics/assembly_building-and-deploying-the-booster-to-openshiftcontaine
 //Interacting with the database
 include::topics/crud-mission-database-interaction.adoc[leveloffset=+3]
 
-:parameter-runtime: spring-boot
-:parameter-runtime-name: {SpringBoot}
 :context: {parameter-mission}-{parameter-runtime}
 include::topics/proc_running-integration-tests.adoc[leveloffset=+3]
 

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -93,14 +93,16 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
+:parameter-runtime: vertx
+:parameter-runtime-name: {Vertx}
+:parameter-mission: crud
+:parameter-mission-name: {name-mission-crud}
+:context: {parameter-mission}-{parameter-runtime}
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
 
 include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
-
-:parameter-mission: crud
-:parameter-mission-name: {name-mission-crud}
 
 :context: {parameter-mission}-oso
 include::topics/assembly_building-and-deploying-the-booster-to-openshiftonline.adoc[leveloffset=+3]
@@ -114,8 +116,6 @@ include::topics/assembly_building-and-deploying-the-booster-to-openshiftcontaine
 
 include::topics/crud-mission-database-interaction.adoc[leveloffset=+3]
 
-:parameter-runtime: vertx
-:parameter-runtime-name: {Vertx}
 :context: {parameter-mission}-{parameter-runtime}
 include::topics/proc_running-integration-tests.adoc[leveloffset=+3]
 

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -116,15 +116,17 @@ include::topics/configmap-mission-resources.adoc[leveloffset=+3]
 
 include::topics/note-booster-unvailable-oso.adoc[leveloffset=+3]
 
+:parameter-runtime: wf-swarm
+:parameter-runtime-name: {WildFlySwarm}
+:parameter-mission: crud
+:parameter-mission-name: {name-mission-crud}
+:context: {parameter-mission}-{parameter-runtime}
 include::topics/crud-mission-intro.adoc[leveloffset=+3]
 
 include::topics/note-preview-booster-source.adoc[leveloffset=+3]
 
 // design tradeoffs
 include::topics/crud-mission-design-tradeoffs.adoc[leveloffset=+3]
-
-:parameter-mission: crud
-:parameter-mission-name: {name-mission-crud}
 
 :context: {parameter-mission}-oso
 include::topics/assembly_building-and-deploying-the-booster-to-openshiftonline.adoc[leveloffset=+3]
@@ -138,8 +140,6 @@ include::topics/assembly_building-and-deploying-the-booster-to-openshiftcontaine
 //Interacting with the database
 include::topics/crud-mission-database-interaction.adoc[leveloffset=+3]
 
-:parameter-runtime: wf-swarm
-:parameter-runtime-name: {WildFlySwarm}
 :context: {parameter-mission}-{parameter-runtime}
 include::topics/proc_running-integration-tests.adoc[leveloffset=+3]
 


### PR DESCRIPTION
The xref in the crud mission info pointed to the configmap integration tests section.
Fixed by moving the relevant parameters before the include statement for the CRUD intro module in the master.adoc files for VX, SB & WF. 
To avoid definig the same values and parameters multiple times per mission, these parameters have been deduplicated and are defined at the top of the section, so that they can be properly consumed by all of the included parameterized modules.