### PR TITLE
Fixes to the Runtime Vertx Guide

### DIFF
--- a/docs/topics/vertx-community-and-product-versions.adoc
+++ b/docs/topics/vertx-community-and-product-versions.adoc
@@ -3,7 +3,7 @@
 
 .Community {Vertx} Version
 // link TBD
-Some of the {Vertx} components included in this release are not fully tested to run on OpenShift, and are provided as a xref:vertx-tech-preview-components[limited-supportability Technology Preview^].
+Some of the {Vertx} components included in this release are not fully tested to run on OpenShift, and are provided as a xref:vertx-tech-preview-components[limited-supportability Technology Preview].
 These components are based on the community version `3.4.2` of {Vertx}.
 
 .Certified {Vertx} Version

--- a/docs/topics/vertx-tech-preview-components.adoc
+++ b/docs/topics/vertx-tech-preview-components.adoc
@@ -8,10 +8,10 @@ Red Hat provides link:https://access.redhat.com/support/offerings/techpreview/[l
 |GroupID | ArtifactID | Version
 |io.vertx | vertx-mongo | 3.4.2.redhat-006
 |io.vertx | vertx-mongo-service | 3.4.2.redhat-006
-|io.vertx | vertx-mongo-client | 3.4.2
+|io.vertx | vertx-mongo-client | 3.4.2.redhat-006
 |io.vertx | vertx-rx | 3.4.2.redhat-006
 |io.vertx | vertx-rx-java | 3.4.2.redhat-006
-|io.vertx | vertx-sockjs-service-proxy | 3.4.2
+|io.vertx | vertx-sockjs-service-proxy | 3.4.2.redhat-006
 |io.vertx | vertx-redis-client | 3.4.2.redhat-006
 |io.vertx | vertx-infinispan | 3.4.2.redhat-006
 |io.vertx | vertx-proton | 3.4.2.redhat-006


### PR DESCRIPTION
* removed the caret in the xref
* fixed up version suffixes for the tech preview section 