### PR TITLE
Small fixes in the WFS Guide

### DIFF
--- a/docs/topics/booster-deploy-openshift-local.adoc
+++ b/docs/topics/booster-deploy-openshift-local.adoc
@@ -1,6 +1,6 @@
 = Deploying the Booster to a {OpenShiftLocal}
 
-. Before you can use a {OpenShiftLocal}, you need to have it installed, configured, and running. You can find more details in link:{link-launcher-openshift-local-install-guide}#installing-a-openshiftlocal[{openshift-local-guide-name}].
+. Before you can use a {OpenShiftLocal}, you need to have it installed, configured, and running. You can find more details in link:{link-launcher-openshift-local-install-guide}#installing-a-openshiftlocal[{minishift-installation-guide-name}].
 
 . Once you have a {OpenShiftLocal} running, check the console output for the URL you can use to access it.
 +

--- a/docs/topics/note-preview-booster-source.adoc
+++ b/docs/topics/note-preview-booster-source.adoc
@@ -1,2 +1,2 @@
 NOTE: To view the source code and README file of this booster, download and extract the ZIP file with the booster.
-To get the download link of the ZIP file, follow the instructions in the link:{link-getting-started-guide}#oso-create-booster[Using OpenShift to Create a Booster] chapter of the {getting-started-guide-name}.
+To get the download link of the ZIP file, follow the instructions in the link:{link-getting-started-guide}#oso-create-booster[Creating and Deploying a Booster Using OpenShift Online] chapter of the {getting-started-guide-name}.

--- a/docs/topics/proc_getting-launcher-url-and-credentials-on-openshiftlocal.adoc
+++ b/docs/topics/proc_getting-launcher-url-and-credentials-on-openshiftlocal.adoc
@@ -12,7 +12,7 @@ You need the {launcher} tool URL and user credentials to create and deploy boost
 
 .Prerequisites
 
-* The {launcher} tool installed, configured, and running. For more information, see the link:{link-launcher-openshift-local-install-guide}[{openshift-local-guide-name}] guide.
+* The {launcher} tool installed, configured, and running. For more information, see the link:{link-launcher-openshift-local-install-guide}[{minishift-installation-guide-name}] guide.
 
 .Procedure
 

--- a/docs/topics/secured-booster-minishift.adoc
+++ b/docs/topics/secured-booster-minishift.adoc
@@ -1,7 +1,7 @@
 = Configuring Your {OpenShiftLocal}
 You can use your {OpenShiftLocal} to run your secured booster, but you need to update it from the default configuration.
 
-. Before you can use your {OpenShiftLocal}, you need to have it installed, configured, and running. You can find details on installing a {OpenShiftLocal} for your platform in link:{link-launcher-openshift-local-install-guide}#installing-a-openshiftlocal[{openshift-local-guide-name}].
+. Before you can use your {OpenShiftLocal}, you need to have it installed, configured, and running. You can find details on installing a {OpenShiftLocal} for your platform in link:{link-launcher-openshift-local-install-guide}#installing-a-openshiftlocal[{minishift-installation-guide-name}].
 +
 NOTE: You only need to do this once for any of the secured booster missions. They can share the same RH SSO/{OpenShiftLocal} setup.
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -70,7 +70,6 @@
 :mission-crud-nodejs-guide-name: {name-mission-crud} Mission - {NodeJS} Booster
 
 
-:openshift-local-guide-name: Install and Configure a {OpenShiftLocal}
 :minishift-installation-guide-name: Install and Configure the {launcher} Tool
 :getting-started-guide-name: Getting Started with {ProductName}
 :landing-page-name: Welcome


### PR DESCRIPTION
I have identified two errors in the WFS Guide:

* The _Using OpenShift to Create a Booster_ chapter in the GSG is now called _reating and Deploying a Booster Using OpenShift Online._
* There was a duplicate usage of the `:minishift-installation-guide-name:` and `:openshift-local-guide-name:` attributes, where the latter had a wrong value. I have replaced all occurrences of the latter with the former.