### PR TITLE
Update H2 database

### DIFF
--- a/docs/topics/thorntail/docs/howto/pom.xml
+++ b/docs/topics/thorntail/docs/howto/pom.xml
@@ -24,7 +24,7 @@
     <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
     <version.guava>19.0.0.redhat-1</version.guava>
     <version.junit>4.11-redhat-1</version.junit>
-    <version.h2>1.4.187</version.h2>
+    <version.h2>2.0.206</version.h2>
     <version.jaxrs-api>1.0.0.Final-redhat-1</version.jaxrs-api>
     <version.postgresql>9.4.1207</version.postgresql>
     <version.mysql>5.1.38</version.mysql>


### PR DESCRIPTION
- This fixes this security issue:
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392.
- More info here:
- GHSA-h376-j262-vhq6